### PR TITLE
solves LisaFC/justdocs#8

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,12 +11,12 @@
     <div class="container-fluid td-outer">
       <div class="td-main">
         <div class="row flex-xl-nowrap">
-          <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
-          </div>
-          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
+          </aside>
+          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
             {{ partial "toc.html" . }}
-          </div>
+          </aside>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}


### PR DESCRIPTION
Solves #8 
Besides the Docsy theme update @LisaFC did recently this change is also needed to have the sidemenu back on the right side.